### PR TITLE
refactor channel chunking

### DIFF
--- a/mkidgen3/server/captures.py
+++ b/mkidgen3/server/captures.py
@@ -4,6 +4,7 @@ import threading
 import time
 import numpy as np
 import zmq
+from typing import Iterable
 import blosc2
 from typing import List
 from npy_append_array import NpyAppendArray
@@ -117,7 +118,7 @@ class CaptureRequest:
         return True
 
     def __init__(self, n: int, tap: str, feedline_config: FeedlineConfig,
-                 feedline_server: FRSClient, channels: list = None, file: str = None,
+                 feedline_server: FRSClient, channels: Iterable | int | None = None, file: str = None,
                  _compression_override: bool = None):
         """
 
@@ -134,9 +135,13 @@ class CaptureRequest:
         self.nsamp = n  # n is treated as the buffer time in ms for photons, and has limits enforced by the driver
         self._last_status = None
         if channels is not None:
+            try:
+                channels = tuple(sorted(set(channels)))
+            except TypeError:
+                channels = (channels,)
             if not CaptureRequest.validate_channels(tap, channels):
                 raise ValueError('Invalid channels specification')
-        self.channels = list(channels) if channels else None
+        self.channels = channels
         self.tap = tap  # maybe add some error handling here
         self.feedline_config = feedline_config
         self.server = feedline_server

--- a/mkidgen3/system_parameters.py
+++ b/mkidgen3/system_parameters.py
@@ -81,6 +81,7 @@ def channel_to_phasegroup(channels: Iterable | int) -> set:
     except TypeError:
         return {channels//16}
 
+
 def phasegroup_to_channel(phase_group: Iterable | int) -> set:
     """
     Convert phase groups to channels.

--- a/mkidgen3/system_parameters.py
+++ b/mkidgen3/system_parameters.py
@@ -1,4 +1,5 @@
 import numpy as np
+from typing import Iterable
 
 DAC_MAX_OUTPUT_DBM = 1  # [dBm] see Xilinx DS926
 DAC_MAX_INT = 8191  # see PG269 p.219
@@ -34,17 +35,64 @@ ADC_MAX_VOLTAGE = 0.22360679774997896  # 0.5/np.sqrt(5) per p.
 from mkidgen3.drivers.ifboard import MAX_IN_ATTEN, IF_ATTN_STEP, MAX_OUT_ATTEN
 
 
-def channel_to_iqgroup(channels):
-    """convert channel number(s) to a set of axi groups in iq"""
+def channel_to_iqgroup(channels: Iterable | int) -> set:
+    """
+    Convert channels to IQ groups which contains those channels.
+    Args:
+        channels: resonator channels (0-2047)
+
+    Returns: set of IQ groups
+
+    """
     try:
         return set([g // 8 for g in channels])
     except TypeError:
-        return channels//8
+        return {channels//8}
 
 
-def channel_to_phasegroup(channels):
-    """convert channel number(s) to a set of axi groups in phase"""
+def iqgroup_to_channel(iq_group: Iterable | int) -> set:
+    """
+    Convert IQ groups to channels.
+    Args:
+        iq_group: (0-128)
+
+    Returns: set of corresponding channels (0-2047)
+
+    """
+    chan_per_group = N_CHANNELS // N_IQ_GROUPS
+    if isinstance(iq_group, int):
+        return set(np.arange(chan_per_group)+iq_group*chan_per_group)
+    else:
+        iq_group = np.fromiter(iq_group, int, len(iq_group))
+        return set((np.arange(chan_per_group)+(iq_group*chan_per_group)[:, np.newaxis]).flatten())
+
+
+def channel_to_phasegroup(channels: Iterable | int) -> set:
+    """
+    Convert phase channels to IQ groups which contains those channels.
+    Args:
+        channels: resonator channels (0-2047)
+
+    Returns: set of IQ groups (0-255)
+
+    """
     try:
         return set([g // 16 for g in channels])
     except TypeError:
-        return channels//16
+        return {channels//16}
+
+def phasegroup_to_channel(phase_group: Iterable | int) -> set:
+    """
+    Convert phase groups to channels.
+    Args:
+        phase_group: (0-127)
+
+    Returns: set of corresponding channels (0-2047)
+
+    """
+    chan_per_group = N_CHANNELS // N_PHASE_GROUPS
+    if isinstance(phase_group, int):
+        return set(np.arange(chan_per_group)+phase_group*chan_per_group)
+    else:
+        phase_group = np.fromiter(phase_group, int, len(phase_group))
+        return set((np.arange(chan_per_group)+(phase_group*chan_per_group)[:, np.newaxis]).flatten())

--- a/tests/frs_test_client.py
+++ b/tests/frs_test_client.py
@@ -1,6 +1,6 @@
 import zmq
 from mkidgen3.server.feedline_config import IFConfig, BitstreamConfig, RFDCClockingConfig, RFDCConfig, WaveformConfig, ChannelConfig, DDCConfig, FeedlineConfig, FilterConfig, TriggerConfig
-from mkidgen3.server.captures import CaptureJob, FRSClient, CaptureRequest,StatusListener
+from mkidgen3.server.captures import CaptureJob, FRSClient, CaptureRequest, StatusListener
 from mkidgen3.server.waveform import WaveformFactory
 from mkidgen3.opfb import opfb_bin_number
 import numpy as np
@@ -16,7 +16,7 @@ if frs == 'a':
 elif frs == 'b':
     server = FRSClient(url='rfsoc4x2b.physics.ucsb.edu', command_port=8888, data_port=8889, status_port=8890)
 # Status listener
-gsm = StatusListener(b'', server.status_url)
+#gsm = StatusListener(b'', server.status_url)
 
 # Bitstream Config
 bitstream = BitstreamConfig(bitstream='/home/xilinx/gen3_top_final.bit', ignore_version=True)
@@ -32,7 +32,7 @@ if_cfgs = [if_board0, if_board1]
 waveform0 = WaveformConfig(waveform=WaveformFactory(n_uniform_tones=512))
 waveform1 = WaveformConfig(waveform=WaveformFactory(n_uniform_tones=1024))
 output_waveform = waveform0.waveform.output_waveform # trigger waveform computation
-output_waveform = waveform1.waveform.output_waveform # trigger waveform computation
+#output_waveform = waveform1.waveform.output_waveform # trigger waveform computation
 wvfm_cfgs = [waveform0, waveform1]
 # Bin2Res Config
 chan0 = waveform0.default_channel_config
@@ -48,9 +48,14 @@ for i in [0, 1]:
     fcs.append(FeedlineConfig(bitstream=bitstream, rfdc_clk=rfdc_clk, rfdc=rfdc,
                     if_board=if_cfgs[i], waveform=wvfm_cfgs[i], chan=b2r_cfgs[i], ddc=ddc_cfgs[i]))
 
+cr = CaptureRequest(1024, 'ddciq', fcs[0], server, channels=[4, 8, 12])
+j = CaptureJob(cr)
+j.submit(True, True)
+
+
 crs = []
 crs.append(CaptureRequest(2**14, 'adc', fcs[0], server))
-crs.append(CaptureRequest(2**34, 'adc', fcs[0], server))
+crs.append(CaptureRequest(2**29, 'adc', fcs[0], server))
 crs.append(CaptureRequest(2**7, 'adc', fcs[1], server))
 crs.append(CaptureRequest(2**14, 'ddciq', fcs[0], server))
 crs.append(CaptureRequest(2, 'ddciq', fcs[0], server))
@@ -58,7 +63,7 @@ crs.append(CaptureRequest(2, 'ddciq', fcs[0], server, channels=[0, 2, 3]))
 crs.append(CaptureRequest(2**16, 'ddciq', fcs[1], server, channels=[0, 2, 3]))
 crs.append(CaptureRequest(2**14, 'filtphase', fcs[0], server, channels=[0, 1, 2, 3, 4, 5, 6, 7, 8]))
 crs.append(CaptureRequest(2**8, 'filtphase', fcs[1], server))
-crs.append(CaptureRequest(2**31, 'filtphase', fcs[0], server, channels=[8, 9, 10]))
+crs.append(CaptureRequest(2**26, 'filtphase', fcs[0], server, channels=[8, 9, 10]))
 
 jobs = []
 for i, cr in enumerate(crs):


### PR DESCRIPTION
refactor channel chunking to incorporate hardware requirements for capture as they differ from user requested channel subset.
* fixes driver bug where groups was not made an even number
* new helper functions to convert groups <--> channels for phase and IQ
* renamed `keep_channels` to `keep_groups` because it returned groups not channels (I can undo this without protest)
* chunking for capture size takes into account required hardware capture size and chunks accordingly
* if pynq buffer can be sliced, it is and the requested data is returned without a copy, if it cannot be sliced, the requested data is copied to PS RAM