### PR TITLE
waveform improvements

### DIFF
--- a/mkidgen3/funcs.py
+++ b/mkidgen3/funcs.py
@@ -149,7 +149,7 @@ def quantize_to_int(x: Iterable[float | int] | int, resolution: int = DAC_RESOLU
     Returns: Quantized value(s)
 
     """
-    assert dyn_range in (0, 1), "dyn_range must be between 0 and 1"
+    assert 0 <= dyn_range <= 1, "dyn_range must be between 0 and 1"
     x = np.asarray(x)
     max_allowed = np.round(dyn_range * (2 ** (resolution - signed) - 1)).astype(int)
     min_allowed = np.round(-dyn_range * (2 ** (resolution - signed))).astype(int)
@@ -192,16 +192,17 @@ def complex_scale(z, max_val):
     return max_val * z / input_max
 
 
-def uniform_freqs(n_channels=N_CHANNELS, bandwidth=SYSTEM_BANDWIDTH):
+def uniform_freqs(n_channels: int = N_CHANNELS, bandwidth:float | int = SYSTEM_BANDWIDTH, offset: float | int = 0.5e6) -> np.ndarray:
     """
-    inputs:
-    - n_channels: int
-        Number of channels in the DDC
-    - BANDWIDTH: float
-        Full channelizer bandwidth (ADC Nyquist bandwidth) in Hz
-    Returns a comb with one frequency per DDC channel, evenly spaced in the bandwidth.
+    Returns a list of frequencies corresponding to one per DDC channel, evenly spaced in the bandwidth.
+    Args:
+        n_channels: Number of channels in the DDC
+        bandwidth: Full channelizer bandwidth (ADC Nyquist bandwidth) in Hz
+        offset: move tones this far from a bin cetner in Hz
+
+    Returns: See above.
     """
-    return np.linspace(-n_channels / 2, n_channels / 2 - 1, n_channels) * (bandwidth / n_channels)
+    return np.linspace(-n_channels / 2, n_channels / 2 - 1, n_channels) * (bandwidth / n_channels)+offset
 
 
 def est_loop_centers(iq):

--- a/mkidgen3/system_parameters.py
+++ b/mkidgen3/system_parameters.py
@@ -14,7 +14,9 @@ ADC_MAX_V = 1/(2*np.sqrt(5))  # [V]. 1 dbM is 1 mW, using P = V^2/R where P is 1
 # V is 1/sqrt(10) volts at the die termination which means the max-scale V is  1/2*sqrt(5) at the SMA input.
 DAC_RESOLUTION = 14  # bits see PG269 p.219
 DAC_LUT_SIZE = 2 ** 19  # values
-DAC_SAMPLE_RATE = 4.096e9  # GSPS
+ADC_SAMPLE_RATE = 4.096e9  # Hz
+DAC_SAMPLE_RATE = 4.096e9  # Hz
+DAC_FREQ_RES = DAC_SAMPLE_RATE / DAC_LUT_SIZE
 N_OPFB_CHANNELS = 4096  # Number of OPFB channels
 N_CHANNELS = 2048  # Number of DDC (resonator) channels
 N_PHASE_GROUPS = 128  # See HLS and the phase drivers, the AXI streams are 16 channels wide

--- a/tests/wvfm_gen_test.py
+++ b/tests/wvfm_gen_test.py
@@ -1,0 +1,21 @@
+from mkidgen3.server.waveform import WaveformFactory, FreqlistWaveform
+import numpy as np
+from mkidgen3.system_parameters import DAC_SAMPLE_RATE, DAC_FREQ_RES, DAC_LUT_SIZE
+import scipy.signal as sig
+import pytest
+
+test_wvfms = [WaveformFactory(frequencies=[200e6, 400e6 + 7812.5], amplitudes=[2, 3], compute=True),
+              WaveformFactory(n_uniform_tones=2048, compute=True),
+              WaveformFactory(n_uniform_tones=2048, dac_dynamic_range=0.8, compute=True)]
+
+
+@pytest.mark.parametrize("wvfm", test_wvfms)
+def test_wvfm(wvfm: FreqlistWaveform) -> None:
+    """
+    Inspect generated waveform via FFT and ensure the tones are at the right frequencies.
+    """
+    fft_abs = np.abs(np.fft.fftshift(np.fft.fft(wvfm.quant_vals)))
+    tones, _ = sig.find_peaks(fft_abs, height=np.mean(fft_abs))
+    possible_tones = np.linspace(-DAC_SAMPLE_RATE / 2, (DAC_SAMPLE_RATE / 2) - DAC_FREQ_RES, DAC_LUT_SIZE)
+
+    assert (possible_tones[tones] == wvfm.quant_freqs).all


### PR DESCRIPTION
Improvements to waveform generation. 

**Highlights:**
* waveform calculation is sped up using IFFT
* quantization and phase randomization are split into separate steps (more logical and flexible than coupling the two)
* support for using a fraction of the full DAC dynamic range
* actual test for waveform which verifies tones are in the right places

**Example Usage:**
Bespoke waveform:
`WaveformFactory(frequencies=[200e6, 400e6 + 7812.5], amplitudes=[2, 3], compute=True)`
Powersweep comb:
`WaveformFactory(n_uniform_tones=2048, compute=True)`
Powersweep comb partial dac dynamic range (max min quantized vals ~= 0.8*32k)
`WaveformFactory(n_uniform_tones=2048, dac_dynamic_range=0.8, compute=True)`

**Future Work:**
Include support for calculating the expected power of each tone exiting the dac, more tests

